### PR TITLE
feat: add configurable facilitator URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,32 @@ Since no real wallet is signing payments, every request gets a 402 back with the
 - **Multi-chain** — accept payments on Base, Solana, or any supported network
 - **Path rewriting** — your public API shape doesn't need to match upstream
 - **Env var interpolation** — `${API_KEY}` in config, secrets stay in `.env`
+- **Custom facilitator** — point to a self-hosted or alternative facilitator
+
+## Custom Facilitator
+
+By default, tollbooth uses `https://x402.org/facilitator`. You can override this globally or per-route:
+
+```yaml
+# Use a custom facilitator for all routes
+facilitator: https://custom-facilitator.example.com
+
+upstreams:
+  myapi:
+    url: https://api.example.com
+
+routes:
+  "GET /data":
+    upstream: myapi
+    price: "$0.01"
+
+  "POST /special":
+    upstream: myapi
+    price: "$0.05"
+    facilitator: https://other-facilitator.example.com  # per-route override
+```
+
+Route-level `facilitator` takes precedence over the top-level setting. If neither is specified, the default `https://x402.org/facilitator` is used.
 
 ## Dynamic Pricing
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -110,4 +110,61 @@ describe("tollboothConfigSchema", () => {
 		});
 		expect(result.success).toBe(false);
 	});
+
+	test("accepts top-level facilitator url", () => {
+		const result = tollboothConfigSchema.safeParse({
+			...validConfig,
+			facilitator: "https://custom-facilitator.example.com",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.facilitator).toBe(
+				"https://custom-facilitator.example.com",
+			);
+		}
+	});
+
+	test("accepts route-level facilitator url", () => {
+		const result = tollboothConfigSchema.safeParse({
+			...validConfig,
+			routes: {
+				"GET /test": {
+					upstream: "api",
+					price: "$0.01",
+					facilitator: "https://route-facilitator.example.com",
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects invalid facilitator url at top level", () => {
+		const result = tollboothConfigSchema.safeParse({
+			...validConfig,
+			facilitator: "not-a-url",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects invalid facilitator url at route level", () => {
+		const result = tollboothConfigSchema.safeParse({
+			...validConfig,
+			routes: {
+				"GET /test": {
+					upstream: "api",
+					price: "$0.01",
+					facilitator: "not-a-url",
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("facilitator is optional (backwards compatible)", () => {
+		const result = tollboothConfigSchema.safeParse(validConfig);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.facilitator).toBeUndefined();
+		}
+	});
 });

--- a/src/__tests__/facilitator.test.ts
+++ b/src/__tests__/facilitator.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { generateDiscoveryMetadata } from "../discovery/metadata.js";
+import type { TollboothConfig } from "../types.js";
+
+const baseConfig: TollboothConfig = {
+	gateway: { port: 3000, discovery: true },
+	wallets: { base: "0xtest" },
+	accepts: [{ asset: "USDC", network: "base" }],
+	defaults: { price: "$0.001", timeout: 60 },
+	upstreams: {
+		api: { url: "https://api.example.com" },
+	},
+	routes: {
+		"GET /test": {
+			upstream: "api",
+			price: "$0.01",
+		},
+	},
+};
+
+describe("facilitator in discovery metadata", () => {
+	test("no facilitator when not configured", () => {
+		const metadata = generateDiscoveryMetadata(baseConfig);
+		expect(metadata.endpoints[0].facilitator).toBeUndefined();
+	});
+
+	test("top-level facilitator appears on all endpoints", () => {
+		const config: TollboothConfig = {
+			...baseConfig,
+			facilitator: "https://custom.example.com",
+		};
+		const metadata = generateDiscoveryMetadata(config);
+		expect(metadata.endpoints[0].facilitator).toBe(
+			"https://custom.example.com",
+		);
+	});
+
+	test("route-level facilitator overrides top-level", () => {
+		const config: TollboothConfig = {
+			...baseConfig,
+			facilitator: "https://global.example.com",
+			routes: {
+				"GET /test": {
+					upstream: "api",
+					price: "$0.01",
+					facilitator: "https://route.example.com",
+				},
+				"POST /other": {
+					upstream: "api",
+					price: "$0.02",
+				},
+			},
+		};
+		const metadata = generateDiscoveryMetadata(config);
+		const testEndpoint = metadata.endpoints.find((e) => e.path === "/test");
+		const otherEndpoint = metadata.endpoints.find((e) => e.path === "/other");
+
+		expect(testEndpoint?.facilitator).toBe("https://route.example.com");
+		expect(otherEndpoint?.facilitator).toBe("https://global.example.com");
+	});
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -43,6 +43,7 @@ const routeConfigSchema = z.object({
 	payTo: payToSchema.optional(),
 	hooks: routeHooksSchema,
 	metadata: z.record(z.unknown()).optional(),
+	facilitator: z.string().url().optional(),
 });
 
 const upstreamConfigSchema = z.object({
@@ -76,6 +77,8 @@ export const tollboothConfigSchema = z.object({
 	routes: z.record(routeConfigSchema),
 
 	hooks: routeHooksSchema,
+
+	facilitator: z.string().url().optional(),
 });
 
 export type TollboothConfigInput = z.input<typeof tollboothConfigSchema>;

--- a/src/discovery/metadata.ts
+++ b/src/discovery/metadata.ts
@@ -15,6 +15,7 @@ export interface DiscoveryEndpoint {
 		defaultPrice?: string;
 	};
 	accepts: { asset: string; network: string }[];
+	facilitator?: string;
 	metadata?: Record<string, unknown>;
 }
 
@@ -43,11 +44,15 @@ export function generateDiscoveryMetadata(
 			defaultPrice = (route.price as string) ?? config.defaults.price;
 		}
 
+		// Resolve facilitator: route-level > top-level
+		const facilitator = route.facilitator ?? config.facilitator;
+
 		endpoints.push({
 			method: method.toUpperCase(),
 			path,
 			pricing: { type: pricingType, defaultPrice },
 			accepts: accepts.map((a) => ({ asset: a.asset, network: a.network })),
+			...(facilitator && { facilitator }),
 			...(route.metadata && { metadata: route.metadata }),
 		});
 	}

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -156,7 +156,15 @@ export function createGateway(config: TollboothConfig): TollboothGateway {
 				accepts,
 			);
 
-			const settlement = await processPayment(request, requirements);
+			// Resolve facilitator: route-level > top-level > default
+			const facilitatorUrl = route.facilitator ?? config.facilitator;
+			const facilitator = facilitatorUrl ? { url: facilitatorUrl } : undefined;
+
+			const settlement = await processPayment(
+				request,
+				requirements,
+				facilitator,
+			);
 
 			if (!settlement) {
 				// No payment header → return 402

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface TollboothConfig {
 	upstreams: Record<string, UpstreamConfig>;
 	routes: Record<string, RouteConfig>;
 	hooks?: GlobalHooksConfig;
+	facilitator?: string;
 }
 
 export interface GatewayConfig {
@@ -44,6 +45,7 @@ export interface RouteConfig {
 	payTo?: string | PayToSplit[];
 	hooks?: RouteHooksConfig;
 	metadata?: Record<string, unknown>;
+	facilitator?: string;
 }
 
 export interface MatchRule {

--- a/src/x402/middleware.ts
+++ b/src/x402/middleware.ts
@@ -1,6 +1,7 @@
 import type { ResolvedPrice } from "../pricing/resolver.js";
 import type { AcceptedPayment, SettlementInfo } from "../types.js";
 import {
+	type FacilitatorConfig,
 	settlePayment,
 	toSettlementInfo,
 	verifyPayment,
@@ -77,6 +78,7 @@ export function createPaymentRequiredResponse(
 export async function processPayment(
 	request: Request,
 	requirements: PaymentRequirementsPayload[],
+	facilitator?: FacilitatorConfig,
 ): Promise<SettlementInfo | null> {
 	const paymentHeader = request.headers.get(HEADERS.PAYMENT_SIGNATURE);
 
@@ -90,7 +92,11 @@ export async function processPayment(
 	const paymentRequirements = requirements[0];
 
 	// Verify
-	const verification = await verifyPayment(paymentPayload, paymentRequirements);
+	const verification = await verifyPayment(
+		paymentPayload,
+		paymentRequirements,
+		facilitator,
+	);
 	if (!verification.isValid) {
 		throw new PaymentError(
 			`Payment verification failed: ${verification.invalidReason ?? "unknown reason"}`,
@@ -99,7 +105,11 @@ export async function processPayment(
 	}
 
 	// Settle
-	const settlement = await settlePayment(paymentPayload, paymentRequirements);
+	const settlement = await settlePayment(
+		paymentPayload,
+		paymentRequirements,
+		facilitator,
+	);
 	if (!settlement.success) {
 		throw new PaymentError(
 			`Payment settlement failed: ${settlement.errorReason ?? "unknown reason"}`,


### PR DESCRIPTION
## Summary

- Add `facilitator` field to top-level config for setting the default facilitator URL for all routes
- Add `facilitator` field to route-level config for per-route override
- Falls back to `https://x402.org/facilitator` when not specified (backwards compatible)
- Config schema validates facilitator URLs with `z.string().url()`
- Discovery metadata (`/.well-known/x402`) reflects the resolved facilitator per endpoint

Closes #1

## Test plan

- [x] Schema tests: top-level facilitator accepted, route-level facilitator accepted, invalid URLs rejected, optional/backwards-compatible
- [x] Discovery metadata tests: no facilitator when unconfigured, top-level appears on endpoints, route-level overrides top-level
- [x] Type-check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)