### PR TITLE
ci: split check job into parallel lint, typecheck, build, test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,31 +11,46 @@ on:
       - develop
 
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20.x]
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-
-      - name: Install dependencies
-        run:  bun install
-
+      - run: bun install
       - name: Format check
         run: bun run check
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun install
       - name: Type check
         run: bun run type-check
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun install
       - name: Build
         run: bun run build
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun install
       - name: Run tests
         run: bun run test


### PR DESCRIPTION
Splits the single `check` job in CI into four parallel jobs:

- **lint** — `bun run check`
- **typecheck** — `bun run type-check`
- **build** — `bun run build`
- **test** — `bun run test`

Each job runs independently, so PR status checks identify exactly which concern failed and wall-clock time is reduced since all four run in parallel.