### PR TITLE
feat: MPP settlement strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "x402-tollbooth",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x402-tollbooth",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.4.0",
+        "stripe": "^21.0.0",
         "yaml": "^2.7.0",
         "zod": "~3.24.0"
       },
@@ -1115,7 +1116,7 @@
       "version": "20.19.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1797,6 +1798,23 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/stripe": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-21.0.0.tgz",
+      "integrity": "sha512-VlQ1QhjQAhmCgY3g3BgfZFLo8AkJw1r9zTrG4hdjSDX2AcwS5sPz4eHJG0zfzCO8zO/md0Xe+zrkxRqg604ZWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2364,7 +2382,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/viem": {
@@ -2404,6 +2422,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -35,16 +35,17 @@
   },
   "dependencies": {
     "ioredis": "^5.4.0",
+    "stripe": "^21.0.0",
     "yaml": "^2.7.0",
     "zod": "~3.24.0"
   },
   "devDependencies": {
-    "viem": "^2.0.0",
     "@biomejs/biome": "^2.3.14",
     "@types/node": "^20.0.0",
     "esbuild": "^0.24.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
+    "viem": "^2.0.0",
     "vitest": "^3.0.0"
   },
   "keywords": [

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -185,8 +185,13 @@ describe("tollboothConfigSchema", () => {
 			expect(result.data.gateway.cors).toEqual({
 				allowedOrigins: ["https://app.example.com"],
 				allowedMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"],
-				allowedHeaders: ["content-type", "payment-signature"],
-				exposedHeaders: ["payment-required", "payment-response"],
+				allowedHeaders: ["content-type", "payment-signature", "authorization"],
+				exposedHeaders: [
+					"payment-required",
+					"payment-response",
+					"www-authenticate",
+					"payment-receipt",
+				],
 				credentials: false,
 			});
 		}

--- a/src/__tests__/mpp-headers.test.ts
+++ b/src/__tests__/mpp-headers.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "vitest";
+import {
+	base64UrlDecode,
+	base64UrlEncode,
+	isMppAuthorization,
+	parseCredential,
+	serializeChallenge,
+	serializeReceipt,
+} from "../mpp/headers.js";
+import type { MppChallenge } from "../mpp/types.js";
+
+describe("MPP headers", () => {
+	describe("base64url", () => {
+		test("round-trips standard characters", () => {
+			const input = '{"foo":"bar","n":42}';
+			expect(base64UrlDecode(base64UrlEncode(input))).toBe(input);
+		});
+
+		test("produces URL-safe output (no +, /, or =)", () => {
+			const input = "a?b>c<d"; // produces + and / in standard base64
+			const encoded = base64UrlEncode(input);
+			expect(encoded).not.toMatch(/[+/=]/);
+		});
+	});
+
+	describe("serializeChallenge", () => {
+		const challenge: MppChallenge = {
+			id: "abc-123",
+			method: "tempo",
+			intent: "charge",
+			amount: "0.01",
+			currency: "usd",
+			decimals: 6,
+			description: "GET /weather",
+			request: base64UrlEncode('{"address":"0xABC"}'),
+		};
+
+		test("produces Payment scheme header value", () => {
+			const result = serializeChallenge(challenge);
+			expect(result).toMatch(/^Payment /);
+			expect(result).toContain('id="abc-123"');
+			expect(result).toContain('method="tempo"');
+			expect(result).toContain('intent="charge"');
+			expect(result).toContain('amount="0.01"');
+			expect(result).toContain('currency="usd"');
+			expect(result).toContain("decimals=6");
+			expect(result).toContain('description="GET /weather"');
+			expect(result).toContain("request=");
+		});
+
+		test("escapes quotes in description", () => {
+			const c = { ...challenge, description: 'route "test"' };
+			const result = serializeChallenge(c);
+			expect(result).toContain('description="route \\"test\\""');
+		});
+	});
+
+	describe("isMppAuthorization", () => {
+		test("returns true for Payment scheme", () => {
+			expect(isMppAuthorization('Payment id="abc"')).toBe(true);
+		});
+
+		test("returns false for Bearer scheme", () => {
+			expect(isMppAuthorization("Bearer xyz")).toBe(false);
+		});
+
+		test("returns false for empty string", () => {
+			expect(isMppAuthorization("")).toBe(false);
+		});
+	});
+
+	describe("parseCredential", () => {
+		test("parses valid MPP credential", () => {
+			const payload = { from: "0xABC", signature: "0xDEF" };
+			const encoded = base64UrlEncode(JSON.stringify(payload));
+			const header = `Payment id="ch-1", payload="${encoded}"`;
+
+			const result = parseCredential(header);
+			expect(result).not.toBeNull();
+			expect(result?.id).toBe("ch-1");
+			expect(result?.payload).toEqual(payload);
+			expect(result?.rawHeader).toBe(header);
+		});
+
+		test("returns null for Bearer token", () => {
+			expect(parseCredential("Bearer abc")).toBeNull();
+		});
+
+		test("returns null for missing payload", () => {
+			expect(parseCredential('Payment id="abc"')).toBeNull();
+		});
+
+		test("returns null for invalid base64 payload", () => {
+			expect(
+				parseCredential('Payment id="abc", payload="!!!invalid!!!"'),
+			).toBeNull();
+		});
+	});
+
+	describe("serializeReceipt", () => {
+		test("produces correct format", () => {
+			const receipt = { payer: "0xABC", transaction: "0xDEF" };
+			const result = serializeReceipt("ch-1", receipt);
+			expect(result).toContain('id="ch-1"');
+			expect(result).toContain('receipt="');
+			// Verify round-trip
+			const match = result.match(/receipt="([^"]+)"/);
+			expect(match).not.toBeNull();
+			const decoded = JSON.parse(base64UrlDecode(match?.[1]));
+			expect(decoded).toEqual(receipt);
+		});
+	});
+});

--- a/src/__tests__/mpp-settlement.test.ts
+++ b/src/__tests__/mpp-settlement.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { createGateway } from "../gateway.js";
+import { base64UrlEncode } from "../mpp/headers.js";
+import type { TollboothConfig, TollboothGateway } from "../types.js";
+import {
+	mockFacilitator,
+	serve,
+	type TestServer,
+} from "./helpers/test-server.js";
+
+const paymentSig = btoa(
+	JSON.stringify({ x402Version: 2, payload: "mock", from: "0xTestPayer" }),
+);
+
+let upstream: TestServer;
+let facilitator: TestServer;
+let gw: TollboothGateway;
+
+function makeConfig(
+	upstreamPort: number,
+	facilitatorPort: number,
+): TollboothConfig {
+	return {
+		gateway: { port: 0, discovery: false },
+		wallets: { "base-sepolia": "0xTestWallet" },
+		accepts: [{ asset: "USDC", network: "base-sepolia" }],
+		defaults: { price: "$0.001", timeout: 60 },
+		upstreams: { api: { url: `http://localhost:${upstreamPort}` } },
+		routes: {
+			"GET /paid": { upstream: "api", price: "$0.01" },
+		},
+		settlement: {
+			strategy: "mpp",
+			url: `http://localhost:${facilitatorPort}`,
+			methods: [{ type: "tempo" }],
+		},
+	};
+}
+
+afterEach(async () => {
+	await gw?.stop();
+	await upstream?.stop();
+	await facilitator?.stop();
+});
+
+describe("MPP settlement strategy", () => {
+	test("402 response includes both x402 and MPP headers", async () => {
+		upstream = await serve({
+			port: 0,
+			fetch: () => Response.json({ ok: true }),
+		});
+		facilitator = await mockFacilitator({
+			verify: () => Response.json({ isValid: true, payer: "0xTestPayer" }),
+			settle: () =>
+				Response.json({
+					success: true,
+					payer: "0xTestPayer",
+					transaction: "0xtx",
+					network: "base-sepolia",
+				}),
+		});
+
+		const config = makeConfig(upstream.port, facilitator.port);
+		gw = createGateway(config);
+		await gw.start({ silent: true });
+
+		const res = await fetch(`http://localhost:${gw.port}/paid`);
+		expect(res.status).toBe(402);
+
+		// x402 header present
+		expect(res.headers.get("payment-required")).toBeTruthy();
+
+		// MPP header present
+		const wwwAuth = res.headers.get("www-authenticate");
+		expect(wwwAuth).toBeTruthy();
+		expect(wwwAuth).toContain("Payment");
+		expect(wwwAuth).toContain('method="tempo"');
+		expect(wwwAuth).toContain('intent="charge"');
+	});
+
+	test("accepts x402 payment-signature with MPP strategy", async () => {
+		upstream = await serve({
+			port: 0,
+			fetch: () => Response.json({ ok: true }),
+		});
+		facilitator = await mockFacilitator({
+			verify: () => Response.json({ isValid: true, payer: "0xTestPayer" }),
+			settle: () =>
+				Response.json({
+					success: true,
+					payer: "0xTestPayer",
+					transaction: "0xtx",
+					network: "base-sepolia",
+				}),
+		});
+
+		const config = makeConfig(upstream.port, facilitator.port);
+		gw = createGateway(config);
+		await gw.start({ silent: true });
+
+		const res = await fetch(`http://localhost:${gw.port}/paid`, {
+			headers: { "payment-signature": paymentSig },
+		});
+		expect(res.status).toBe(200);
+
+		// Both receipt headers present
+		expect(res.headers.get("payment-response")).toBeTruthy();
+		expect(res.headers.get("payment-receipt")).toBeTruthy();
+	});
+
+	test("accepts MPP Authorization: Payment header", async () => {
+		upstream = await serve({
+			port: 0,
+			fetch: () => Response.json({ ok: true }),
+		});
+		facilitator = await mockFacilitator({
+			verify: () => Response.json({ isValid: true, payer: "0xTestPayer" }),
+			settle: () =>
+				Response.json({
+					success: true,
+					payer: "0xTestPayer",
+					transaction: "0xtx",
+					network: "base-sepolia",
+				}),
+		});
+
+		const config = makeConfig(upstream.port, facilitator.port);
+		gw = createGateway(config);
+		await gw.start({ silent: true });
+
+		// Build an MPP credential
+		const payload = base64UrlEncode(
+			JSON.stringify({
+				x402Version: 2,
+				payload: "mock",
+				from: "0xTestPayer",
+			}),
+		);
+		const mppAuth = `Payment id="test-challenge", payload="${payload}"`;
+
+		const res = await fetch(`http://localhost:${gw.port}/paid`, {
+			headers: { Authorization: mppAuth },
+		});
+		expect(res.status).toBe(200);
+
+		// Both receipt headers present
+		expect(res.headers.get("payment-response")).toBeTruthy();
+		expect(res.headers.get("payment-receipt")).toBeTruthy();
+	});
+
+	test("config validation requires methods for mpp strategy", async () => {
+		const { tollboothConfigSchema } = await import("../config/schema.js");
+
+		const result = tollboothConfigSchema.safeParse({
+			gateway: { port: 3000 },
+			wallets: { "base-sepolia": "0xtest" },
+			accepts: [{ asset: "USDC", network: "base-sepolia" }],
+			defaults: { price: "$0.001", timeout: 60 },
+			upstreams: { api: { url: "http://localhost:8080" } },
+			routes: { "GET /test": { upstream: "api" } },
+			settlement: { strategy: "mpp" },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("config validation accepts valid mpp config", async () => {
+		const { tollboothConfigSchema } = await import("../config/schema.js");
+
+		const result = tollboothConfigSchema.safeParse({
+			gateway: { port: 3000 },
+			wallets: { "base-sepolia": "0xtest" },
+			accepts: [{ asset: "USDC", network: "base-sepolia" }],
+			defaults: { price: "$0.001", timeout: 60 },
+			upstreams: { api: { url: "http://localhost:8080" } },
+			routes: { "GET /test": { upstream: "api" } },
+			settlement: {
+				strategy: "mpp",
+				methods: [
+					{ type: "tempo" },
+					{ type: "stripe", secretKey: "sk_test_xxx" },
+				],
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -91,17 +91,30 @@ const facilitatorMappingSchema = z.object({
 
 const facilitatorSchema = z.union([z.string().url(), facilitatorMappingSchema]);
 
+const mppMethodSchema = z.discriminatedUnion("type", [
+	z.object({ type: z.literal("tempo") }).strict(),
+	z
+		.object({ type: z.literal("stripe"), secretKey: z.string().min(1) })
+		.strict(),
+]);
+
 const settlementStrategySchema = z
 	.object({
-		strategy: z.enum(["facilitator", "custom", "nanopayments"]),
+		strategy: z.enum(["facilitator", "custom", "nanopayments", "mpp"]),
 		url: z.string().url().optional(),
 		module: z.string().min(1).optional(),
 		network: z.enum(["testnet", "mainnet"]).optional(),
+		methods: z.array(mppMethodSchema).min(1).optional(),
 	})
 	.strict()
 	.refine(
 		(data) => data.strategy !== "custom" || !!data.module,
 		"Custom settlement strategy requires a 'module' path",
+	)
+	.refine(
+		(data) =>
+			data.strategy !== "mpp" || (data.methods && data.methods.length > 0),
+		"MPP settlement strategy requires at least one method",
 	);
 
 const redisUrlSchema = z
@@ -190,10 +203,15 @@ const corsSchema = z
 			.default(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]),
 		allowedHeaders: z
 			.array(z.string().min(1))
-			.default(["content-type", "payment-signature"]),
+			.default(["content-type", "payment-signature", "authorization"]),
 		exposedHeaders: z
 			.array(z.string().min(1))
-			.default(["payment-required", "payment-response"]),
+			.default([
+				"payment-required",
+				"payment-response",
+				"www-authenticate",
+				"payment-receipt",
+			]),
 		credentials: z.boolean().default(false),
 		maxAge: z.number().int().nonnegative().optional(),
 	})

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -13,6 +13,11 @@ import {
 	type SettlementStrategyLabel,
 	TollboothPrometheusMetrics,
 } from "./metrics/prometheus.js";
+import {
+	isMppAuthorization,
+	MPP_HEADERS,
+	parseCredential,
+} from "./mpp/headers.js";
 import { resolveClientIp } from "./network/client-ip.js";
 import { extractModel, resolveOpenAIPrice } from "./openai/handler.js";
 import { buildExportSpec, importOpenAPIRoutes } from "./openapi/spec.js";
@@ -43,6 +48,7 @@ import {
 	createFacilitatorStrategy,
 	initSettlementStrategy,
 } from "./settlement/loader.js";
+import { MppSettlement } from "./settlement/mpp.js";
 import { NanopaymentSettlement } from "./settlement/nanopayments.js";
 import {
 	buildRedisStorePrefix,
@@ -698,15 +704,31 @@ export function createGateway(
 						: undefined,
 				);
 
-				// ── Extract payment from request ────────────────────────────────
-				const paymentHeader = request.headers.get(HEADERS.PAYMENT_SIGNATURE);
+				// ── Extract payment from request (MPP or x402) ─────────────────
+				const authHeader = request.headers.get("authorization") ?? "";
+				const mppCredential = isMppAuthorization(authHeader)
+					? parseCredential(authHeader)
+					: null;
+				const paymentHeader = mppCredential
+					? mppCredential.rawHeader
+					: request.headers.get(HEADERS.PAYMENT_SIGNATURE);
+
+				// Build MPP challenges if strategy is MPP (for 402 responses)
+				const mppChallenges =
+					!paymentHeader && customStrategy instanceof MppSettlement
+						? await customStrategy.buildChallenges(requirements, routeKey)
+						: undefined;
+
 				if (!paymentHeader && timeSessionDurationMs == null) {
 					recordPaymentOutcome("missing");
-					return finish(routeKey, createPaymentRequiredResponse(requirements));
+					return finish(
+						routeKey,
+						createPaymentRequiredResponse(requirements, mppChallenges),
+					);
 				}
-				const payment = paymentHeader
-					? decodePaymentSignature(paymentHeader)
-					: null;
+				const payment =
+					mppCredential?.payload ??
+					(paymentHeader ? decodePaymentSignature(paymentHeader) : null);
 
 				// ── Resolve settlement strategy ─────────────────────────────────
 				const strategy =
@@ -785,11 +807,17 @@ export function createGateway(
 				// No payment header → require payment
 				if (!paymentHeader) {
 					recordPaymentOutcome("missing");
-					return finish(routeKey, createPaymentRequiredResponse(requirements));
+					return finish(
+						routeKey,
+						createPaymentRequiredResponse(requirements, mppChallenges),
+					);
 				}
 				if (!payment) {
 					recordPaymentOutcome("rejected");
-					return finish(routeKey, createPaymentRequiredResponse(requirements));
+					return finish(
+						routeKey,
+						createPaymentRequiredResponse(requirements, mppChallenges),
+					);
 				}
 
 				// ── Verification cache config ────────────────────────────────────
@@ -1233,10 +1261,18 @@ export function createGateway(
 		const responseHeaders = new Headers(finalResponse.headers);
 
 		if (settlement) {
+			// x402 receipt header
 			responseHeaders.set(
 				HEADERS.PAYMENT_RESPONSE,
 				encodePaymentResponse(settlement),
 			);
+			// MPP receipt header (when using MPP strategy)
+			if (customStrategy instanceof MppSettlement) {
+				responseHeaders.set(
+					MPP_HEADERS.PAYMENT_RECEIPT,
+					customStrategy.buildReceiptHeader(undefined, settlement),
+				);
+			}
 		}
 
 		if (settlementSkippedReason) {
@@ -1459,9 +1495,11 @@ export function createGateway(
 		cacheConfig: VerificationCacheConfig | undefined,
 	): Promise<SettlementVerification> {
 		const isFacilitator = strategy instanceof FacilitatorSettlement;
+		const isMpp = strategy instanceof MppSettlement;
+		const isCacheable = isFacilitator || isMpp;
 
-		// Try cache (only for facilitator strategy)
-		if (isFacilitator && cacheKey && cacheConfig) {
+		// Try cache (facilitator and MPP strategies)
+		if (isCacheable && cacheKey && cacheConfig) {
 			const cached = await verificationCacheStore.get(cacheKey);
 			if (cached) {
 				metrics?.incCacheHit(routeLabel);
@@ -1486,9 +1524,11 @@ export function createGateway(
 		}
 		const verification = await strategy.verify(payment, requirements);
 
-		// Cache successful verification (facilitator only)
-		if (isFacilitator && cacheKey && cacheConfig) {
-			const idx = FacilitatorSettlement.getRequirementIndex(verification);
+		// Cache successful verification (facilitator and MPP)
+		if (isCacheable && cacheKey && cacheConfig) {
+			const idx = isFacilitator
+				? FacilitatorSettlement.getRequirementIndex(verification)
+				: MppSettlement.getRequirementIndex(verification);
 			if (idx !== undefined) {
 				const ttlMs = parseWindow(cacheConfig.ttl);
 				await verificationCacheStore.set(

--- a/src/mpp/challenge.ts
+++ b/src/mpp/challenge.ts
@@ -1,0 +1,11 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Generate a unique challenge ID for an MPP 402 response.
+ *
+ * Each 402 response gets one challenge ID shared across all methods,
+ * binding the credential back to this specific challenge.
+ */
+export function generateChallengeId(): string {
+	return randomUUID();
+}

--- a/src/mpp/headers.ts
+++ b/src/mpp/headers.ts
@@ -1,0 +1,111 @@
+import type { MppChallenge, MppCredential } from "./types.js";
+
+// ── Header names ────────────────────────────────────────────────────────────
+
+export const MPP_HEADERS = {
+	/** Server → Client: payment challenge (402 response). */
+	WWW_AUTHENTICATE: "www-authenticate",
+	/** Client → Server: payment credential (request). */
+	AUTHORIZATION: "authorization",
+	/** Server → Client: payment receipt (success response). */
+	PAYMENT_RECEIPT: "payment-receipt",
+} as const;
+
+export const MPP_SCHEME = "Payment";
+
+// ── Base64url helpers (RFC 4648 §5) ─────────────────────────────────────────
+
+export function base64UrlEncode(data: string): string {
+	return btoa(data).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function base64UrlDecode(encoded: string): string {
+	let base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+	while (base64.length % 4) base64 += "=";
+	return atob(base64);
+}
+
+// ── Serialize / parse ───────────────────────────────────────────────────────
+
+/**
+ * Serialize an MppChallenge into the `WWW-Authenticate: Payment ...` header value.
+ *
+ * ```
+ * Payment id="abc", method="tempo", intent="charge", amount="0.01",
+ *   currency="usd", decimals=6, description="...", request="<base64url>"
+ * ```
+ */
+export function serializeChallenge(challenge: MppChallenge): string {
+	const parts = [
+		`${MPP_SCHEME} id="${challenge.id}"`,
+		`method="${challenge.method}"`,
+		`intent="${challenge.intent}"`,
+		`amount="${challenge.amount}"`,
+		`currency="${challenge.currency}"`,
+		`decimals=${challenge.decimals}`,
+		`description="${escapeParam(challenge.description)}"`,
+		`request="${challenge.request}"`,
+	];
+	return parts.join(", ");
+}
+
+/**
+ * Check whether an Authorization header uses the MPP `Payment` scheme.
+ */
+export function isMppAuthorization(header: string): boolean {
+	return header.startsWith(`${MPP_SCHEME} `);
+}
+
+/**
+ * Parse an `Authorization: Payment id="...", payload="..."` header.
+ *
+ * Returns null if the header is not a valid MPP credential.
+ */
+export function parseCredential(header: string): MppCredential | null {
+	if (!isMppAuthorization(header)) return null;
+
+	const params = parseParams(header.slice(MPP_SCHEME.length + 1));
+	const id = params.get("id");
+	const payloadEncoded = params.get("payload");
+
+	if (!id || !payloadEncoded) return null;
+
+	try {
+		const decoded = JSON.parse(base64UrlDecode(payloadEncoded));
+		return { id, payload: decoded, rawHeader: header };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Serialize a `Payment-Receipt` header value.
+ */
+export function serializeReceipt(id: string, receipt: unknown): string {
+	const encoded = base64UrlEncode(JSON.stringify(receipt));
+	return `id="${id}", receipt="${encoded}"`;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Escape double-quotes inside a parameter value. */
+function escapeParam(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Parse `key="value", key=value` structured header parameters.
+ * Handles quoted and unquoted values.
+ */
+function parseParams(input: string): Map<string, string> {
+	const params = new Map<string, string>();
+	const regex = /(\w+)=(?:"((?:[^"\\]|\\.)*)"|(\S+?)(?:,|$))/g;
+	for (const match of input.matchAll(regex)) {
+		const key = match[1];
+		const value = match[2] !== undefined ? match[2] : match[3];
+		if (key && value !== undefined) {
+			params.set(key, value.replace(/\\"/g, '"').replace(/\\\\/g, "\\"));
+		}
+	}
+	return params;
+}

--- a/src/mpp/index.ts
+++ b/src/mpp/index.ts
@@ -1,0 +1,22 @@
+export { generateChallengeId } from "./challenge.js";
+export {
+	base64UrlDecode,
+	base64UrlEncode,
+	isMppAuthorization,
+	MPP_HEADERS,
+	MPP_SCHEME,
+	parseCredential,
+	serializeChallenge,
+	serializeReceipt,
+} from "./headers.js";
+export { StripeMethod } from "./stripe.js";
+export { TempoMethod } from "./tempo.js";
+export type {
+	MppChallenge,
+	MppCredential,
+	MppMethod,
+	MppMethodConfig,
+	MppMethodType,
+	MppReceipt,
+	MppVerification,
+} from "./types.js";

--- a/src/mpp/stripe.ts
+++ b/src/mpp/stripe.ts
@@ -1,0 +1,162 @@
+import Stripe from "stripe";
+import type {
+	PaymentRequirementsPayload,
+	SettlementInfo,
+	SettlementVerification,
+} from "../types.js";
+import { PaymentError } from "../x402/middleware.js";
+import { base64UrlEncode } from "./headers.js";
+import type { MppChallenge, MppMethod } from "./types.js";
+
+interface StripeVerification extends SettlementVerification {
+	paymentIntentId: string;
+	requirementIndex: number;
+	amount: string;
+	currency: string;
+}
+
+/**
+ * Stripe payment method for MPP.
+ *
+ * Accepts fiat card payments via Stripe's Shared Payment Tokens (SPT).
+ * The server creates a PaymentIntent as the challenge, the client
+ * confirms it with their SPT, and the server verifies completion.
+ */
+export class StripeMethod implements MppMethod {
+	readonly type = "stripe" as const;
+	private stripe: Stripe;
+
+	constructor(config: { secretKey: string }) {
+		this.stripe = new Stripe(config.secretKey);
+	}
+
+	async buildChallenge(
+		requirement: PaymentRequirementsPayload,
+		challengeId: string,
+		description: string,
+	): Promise<MppChallenge> {
+		// Convert from smallest units (e.g. USDC 6 decimals) to Stripe's
+		// smallest unit (cents for USD). USDC amounts are in 10^6; Stripe
+		// wants cents (10^2), so divide by 10^4.
+		const rawAmount = BigInt(requirement.maxAmountRequired);
+		const stripeAmount = Number(rawAmount / 10_000n) || 1; // minimum 1 cent
+
+		const intent = await this.stripe.paymentIntents.create({
+			amount: stripeAmount,
+			currency: "usd",
+			payment_method_types: ["card"],
+			metadata: {
+				mpp_challenge_id: challengeId,
+				resource: requirement.resource,
+				network: requirement.network,
+			},
+		});
+
+		const request = base64UrlEncode(
+			JSON.stringify({
+				clientSecret: intent.client_secret,
+				paymentIntentId: intent.id,
+			}),
+		);
+
+		return {
+			id: challengeId,
+			method: "stripe",
+			intent: "charge",
+			amount: (stripeAmount / 100).toFixed(2),
+			currency: "usd",
+			decimals: 2,
+			description,
+			request,
+		};
+	}
+
+	async verify(
+		payload: unknown,
+		_requirements: PaymentRequirementsPayload[],
+	): Promise<SettlementVerification> {
+		const cred = payload as Record<string, unknown>;
+
+		// The credential payload should contain the confirmed PaymentIntent ID
+		const paymentIntentId =
+			(cred.paymentIntentId as string) ?? (cred.id as string);
+		if (!paymentIntentId || typeof paymentIntentId !== "string") {
+			throw new PaymentError("Missing paymentIntentId in credential", 402);
+		}
+
+		// Retrieve the PaymentIntent to check its status
+		let intent: Stripe.PaymentIntent;
+		try {
+			intent = await this.stripe.paymentIntents.retrieve(paymentIntentId);
+		} catch (err) {
+			throw new PaymentError(
+				err instanceof Error
+					? `Stripe verification failed: ${err.message}`
+					: "Stripe verification failed",
+				402,
+			);
+		}
+
+		if (intent.status !== "succeeded" && intent.status !== "requires_capture") {
+			// If the client sent a payment_method (SPT), try to confirm
+			const paymentMethod = cred.paymentMethod as string | undefined;
+			if (paymentMethod) {
+				try {
+					intent = await this.stripe.paymentIntents.confirm(paymentIntentId, {
+						payment_method: paymentMethod,
+					});
+				} catch (err) {
+					throw new PaymentError(
+						err instanceof Error
+							? `Stripe payment failed: ${err.message}`
+							: "Stripe payment failed",
+						402,
+					);
+				}
+			}
+
+			if (
+				intent.status !== "succeeded" &&
+				intent.status !== "requires_capture"
+			) {
+				throw new PaymentError(
+					`Stripe payment not completed (status: ${intent.status})`,
+					402,
+				);
+			}
+		}
+
+		const verification: StripeVerification = {
+			payer: intent.metadata?.payer ?? `stripe:${intent.id}`,
+			paymentIntentId: intent.id,
+			requirementIndex: 0,
+			amount: intent.amount.toString(),
+			currency: intent.currency,
+		};
+		return verification;
+	}
+
+	async settle(verification: SettlementVerification): Promise<SettlementInfo> {
+		if (!isStripeVerification(verification)) {
+			throw new PaymentError(
+				"settle() received a verification not produced by StripeMethod",
+				500,
+			);
+		}
+
+		// Stripe PaymentIntents are captured on confirm (automatic capture).
+		// Nothing more to do — return the settlement info.
+		return {
+			payer: verification.payer ?? `stripe:${verification.paymentIntentId}`,
+			amount: verification.amount,
+			transaction: verification.paymentIntentId,
+			network: "stripe",
+		};
+	}
+}
+
+function isStripeVerification(
+	v: SettlementVerification,
+): v is StripeVerification {
+	return "paymentIntentId" in v;
+}

--- a/src/mpp/tempo.ts
+++ b/src/mpp/tempo.ts
@@ -1,0 +1,181 @@
+import type {
+	PaymentRequirementsPayload,
+	SettlementInfo,
+	SettlementVerification,
+} from "../types.js";
+import {
+	type FacilitatorConfig,
+	settlePayment,
+	toSettlementInfo,
+	verifyPayment,
+} from "../x402/facilitator.js";
+import { PaymentError } from "../x402/middleware.js";
+import { base64UrlEncode } from "./headers.js";
+import type { MppChallenge, MppMethod } from "./types.js";
+
+// Token metadata for MPP challenge formatting.
+// USDC has 6 decimals and is denominated in USD.
+const ASSET_META: Record<string, { currency: string; decimals: number }> = {
+	USDC: { currency: "usd", decimals: 6 },
+};
+
+interface TempoVerification extends SettlementVerification {
+	paymentPayload: unknown;
+	requirement: PaymentRequirementsPayload;
+	requirementIndex: number;
+	facilitator: FacilitatorConfig;
+}
+
+/**
+ * Tempo payment method for MPP.
+ *
+ * Wraps the existing x402 facilitator settlement, mapping between
+ * MPP challenge/credential format and x402 verify/settle calls.
+ */
+export class TempoMethod implements MppMethod {
+	readonly type = "tempo" as const;
+
+	constructor(private facilitators: FacilitatorConfig[]) {}
+
+	buildChallenge(
+		requirement: PaymentRequirementsPayload,
+		challengeId: string,
+		description: string,
+	): MppChallenge {
+		const meta = resolveAssetMeta(requirement.asset);
+		const amount = formatAmount(requirement.maxAmountRequired, meta.decimals);
+
+		const request = base64UrlEncode(
+			JSON.stringify({
+				address: requirement.payTo,
+				network: requirement.network,
+				asset: requirement.asset,
+				extra: requirement.extra,
+				scheme: requirement.scheme,
+				maxTimeoutSeconds: requirement.maxTimeoutSeconds,
+			}),
+		);
+
+		return {
+			id: challengeId,
+			method: "tempo",
+			intent: "charge",
+			amount,
+			currency: meta.currency,
+			decimals: meta.decimals,
+			description,
+			request,
+		};
+	}
+
+	async verify(
+		payload: unknown,
+		requirements: PaymentRequirementsPayload[],
+	): Promise<SettlementVerification> {
+		let lastError: PaymentError | null = null;
+
+		for (let i = 0; i < requirements.length; i++) {
+			const req = requirements[i];
+			const facilitator = this.facilitators[i] ?? this.facilitators[0];
+
+			try {
+				const result = await verifyPayment(payload, req, facilitator);
+				if (!result.isValid) {
+					lastError = new PaymentError(
+						`Payment verification failed: ${result.invalidReason ?? "unknown reason"}`,
+						402,
+					);
+					continue;
+				}
+
+				const verification: TempoVerification = {
+					payer: result.payer,
+					paymentPayload: payload,
+					requirement: req,
+					requirementIndex: i,
+					facilitator,
+				};
+				return verification;
+			} catch (err) {
+				lastError = new PaymentError(
+					err instanceof Error ? err.message : "Verification failed",
+					402,
+				);
+			}
+		}
+
+		throw (
+			lastError ??
+			new PaymentError(
+				"Payment verification failed for all payment methods",
+				402,
+			)
+		);
+	}
+
+	async settle(verification: SettlementVerification): Promise<SettlementInfo> {
+		if (!isTempoVerification(verification)) {
+			throw new PaymentError(
+				"settle() received a verification not produced by TempoMethod.verify()",
+				500,
+			);
+		}
+		const { paymentPayload, requirement, facilitator } = verification;
+
+		let settlement: Awaited<ReturnType<typeof settlePayment>>;
+		try {
+			settlement = await settlePayment(
+				paymentPayload,
+				requirement,
+				facilitator,
+			);
+		} catch (err) {
+			throw new PaymentError(
+				err instanceof Error ? err.message : "Settlement failed",
+				502,
+			);
+		}
+		if (!settlement.success) {
+			throw new PaymentError(
+				`Payment settlement failed: ${settlement.errorReason ?? "unknown reason"}`,
+				502,
+			);
+		}
+
+		const info = toSettlementInfo(settlement);
+		info.amount = requirement.maxAmountRequired;
+		return info;
+	}
+}
+
+function isTempoVerification(
+	v: SettlementVerification,
+): v is TempoVerification {
+	return "paymentPayload" in v && "requirement" in v && "facilitator" in v;
+}
+
+function resolveAssetMeta(asset: string): {
+	currency: string;
+	decimals: number;
+} {
+	// Match by known contract addresses or symbol
+	for (const [symbol, meta] of Object.entries(ASSET_META)) {
+		if (asset.toUpperCase() === symbol) return meta;
+	}
+	// Default to USDC-like properties for known USDC contract addresses
+	return { currency: "usd", decimals: 6 };
+}
+
+/**
+ * Format a raw amount string (smallest units) to a human-readable decimal.
+ * e.g. "1000" with 6 decimals → "0.001"
+ */
+function formatAmount(raw: string, decimals: number): string {
+	const n = BigInt(raw);
+	const divisor = 10n ** BigInt(decimals);
+	const whole = n / divisor;
+	const frac = n % divisor;
+	if (frac === 0n) return whole.toString();
+	const fracStr = frac.toString().padStart(decimals, "0").replace(/0+$/, "");
+	return `${whole}.${fracStr}`;
+}

--- a/src/mpp/types.ts
+++ b/src/mpp/types.ts
@@ -1,0 +1,89 @@
+import type {
+	PaymentRequirementsPayload,
+	SettlementInfo,
+	SettlementVerification,
+} from "../types.js";
+
+// ── Method types ────────────────────────────────────────────────────────────
+
+export type MppMethodType = "tempo" | "stripe";
+
+export interface TempoMethodConfig {
+	type: "tempo";
+}
+
+export interface StripeMethodConfig {
+	type: "stripe";
+	secretKey: string;
+}
+
+export type MppMethodConfig = TempoMethodConfig | StripeMethodConfig;
+
+// ── Protocol primitives ─────────────────────────────────────────────────────
+
+export interface MppChallenge {
+	id: string;
+	method: MppMethodType;
+	intent: "charge" | "session";
+	amount: string;
+	currency: string;
+	decimals: number;
+	description: string;
+	/** Base64url-encoded method-specific payment request data. */
+	request: string;
+}
+
+export interface MppCredential {
+	id: string;
+	/** Decoded payment payload from the credential. */
+	payload: unknown;
+	/** The raw Authorization header value (for cache key compatibility). */
+	rawHeader: string;
+}
+
+export interface MppReceipt {
+	id: string;
+	receipt: unknown;
+}
+
+// ── Method interface ────────────────────────────────────────────────────────
+
+export interface MppMethod {
+	type: MppMethodType;
+
+	/**
+	 * Build an MPP challenge for a 402 response.
+	 * May be async (e.g. Stripe creates a PaymentIntent).
+	 */
+	buildChallenge(
+		requirement: PaymentRequirementsPayload,
+		challengeId: string,
+		description: string,
+	): MppChallenge | Promise<MppChallenge>;
+
+	/**
+	 * Verify a credential payload submitted by the client.
+	 */
+	verify(
+		payload: unknown,
+		requirements: PaymentRequirementsPayload[],
+	): Promise<SettlementVerification>;
+
+	/**
+	 * Settle (finalize) a verified payment.
+	 */
+	settle(verification: SettlementVerification): Promise<SettlementInfo>;
+}
+
+// ── Settlement verification extension ───────────────────────────────────────
+
+export interface MppVerification extends SettlementVerification {
+	/** Which method handled this payment. */
+	methodType: MppMethodType;
+	/** The challenge ID that was fulfilled. */
+	challengeId?: string;
+	/** Index into the requirements array (for cache support). */
+	requirementIndex: number;
+	/** Strategy-specific inner verification data. */
+	inner: SettlementVerification;
+}

--- a/src/settlement/loader.ts
+++ b/src/settlement/loader.ts
@@ -1,5 +1,7 @@
 import { createRequire } from "node:module";
 import { log } from "../logger.js";
+import { StripeMethod } from "../mpp/stripe.js";
+import { TempoMethod } from "../mpp/tempo.js";
 import type {
 	AcceptedPayment,
 	FacilitatorMapping,
@@ -7,8 +9,12 @@ import type {
 	SettlementStrategy,
 	SettlementStrategyConfig,
 } from "../types.js";
-import { resolveFacilitatorUrl } from "../x402/facilitator.js";
+import {
+	DEFAULT_FACILITATOR,
+	resolveFacilitatorUrl,
+} from "../x402/facilitator.js";
 import { FacilitatorSettlement } from "./facilitator.js";
+import { MppSettlement } from "./mpp.js";
 import { NanopaymentSettlement } from "./nanopayments.js";
 
 const strategyCache = new Map<string, SettlementStrategy>();
@@ -106,6 +112,34 @@ export async function initSettlementStrategy(config: {
 		});
 		await strategy.init();
 		return strategy;
+	}
+
+	if (config.settlement?.strategy === "mpp") {
+		if (!config.settlement.methods?.length) {
+			throw new Error("MPP settlement strategy requires at least one method");
+		}
+
+		// Resolve facilitator URLs for tempo methods
+		const facilitatorUrl =
+			config.settlement.url ??
+			(typeof config.facilitator === "string"
+				? config.facilitator
+				: config.facilitator?.default) ??
+			DEFAULT_FACILITATOR;
+
+		const methods = config.settlement.methods.map((m) => {
+			if (m.type === "tempo") {
+				return new TempoMethod([{ url: facilitatorUrl }]);
+			}
+			if (m.type === "stripe") {
+				return new StripeMethod({ secretKey: m.secretKey });
+			}
+			throw new Error(
+				`Unknown MPP method type: ${(m as { type: string }).type}`,
+			);
+		});
+
+		return new MppSettlement(methods);
 	}
 
 	if (config.settlement?.strategy === "custom") {

--- a/src/settlement/mpp.ts
+++ b/src/settlement/mpp.ts
@@ -1,0 +1,210 @@
+import { log } from "../logger.js";
+import { generateChallengeId } from "../mpp/challenge.js";
+import {
+	type MppChallenge,
+	type MppMethod,
+	type MppVerification,
+	serializeChallenge,
+	serializeReceipt,
+} from "../mpp/index.js";
+import type {
+	PaymentRequirementsPayload,
+	SettlementInfo,
+	SettlementStrategy,
+	SettlementVerification,
+} from "../types.js";
+import { PaymentError } from "../x402/middleware.js";
+
+/**
+ * MPP settlement strategy.
+ *
+ * Manages multiple payment methods (tempo, stripe, etc.) under the MPP
+ * protocol. Generates MPP-format challenges, routes credentials to the
+ * correct method, and produces dual-format receipts.
+ */
+export class MppSettlement implements SettlementStrategy {
+	/** Methods in priority order (first = preferred). */
+	private methods: MppMethod[];
+
+	/**
+	 * Maps challenge IDs to the method type that generated them.
+	 * Entries are cleaned up after a TTL to prevent unbounded growth.
+	 */
+	private challengeMap = new Map<
+		string,
+		{ method: string; expiresAt: number }
+	>();
+	private static CHALLENGE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+	constructor(methods: MppMethod[]) {
+		this.methods = methods;
+	}
+
+	// ── Challenge generation (called by gateway for 402 responses) ──────────
+
+	/**
+	 * Build MPP challenges for all methods × all requirements.
+	 * Returns one challenge per method (using the first requirement for each).
+	 */
+	async buildChallenges(
+		requirements: PaymentRequirementsPayload[],
+		description: string,
+	): Promise<MppChallenge[]> {
+		this.sweepExpired();
+		const challengeId = generateChallengeId();
+		const challenges: MppChallenge[] = [];
+
+		for (const method of this.methods) {
+			// Use the first requirement for the challenge (client picks method, not requirement)
+			const req = requirements[0];
+			const challenge = await method.buildChallenge(
+				req,
+				challengeId,
+				description,
+			);
+			challenges.push(challenge);
+
+			// Track which method owns this challenge
+			this.challengeMap.set(`${challengeId}:${method.type}`, {
+				method: method.type,
+				expiresAt: Date.now() + MppSettlement.CHALLENGE_TTL_MS,
+			});
+		}
+
+		return challenges;
+	}
+
+	/**
+	 * Serialize challenges into WWW-Authenticate header values.
+	 */
+	serializeChallengeHeaders(challenges: MppChallenge[]): string[] {
+		return challenges.map(serializeChallenge);
+	}
+
+	/**
+	 * Build a Payment-Receipt header value for a settlement.
+	 */
+	buildReceiptHeader(
+		challengeId: string | undefined,
+		settlement: SettlementInfo,
+	): string {
+		return serializeReceipt(challengeId ?? "none", settlement);
+	}
+
+	// ── SettlementStrategy interface ────────────────────────────────────────
+
+	async verify(
+		payment: unknown,
+		requirements: PaymentRequirementsPayload[],
+	): Promise<SettlementVerification> {
+		// Try each method in order — the payment format determines which succeeds.
+		// For x402-compatible clients sending stablecoin proofs, tempo will match.
+		// For Stripe SPT clients, stripe will match.
+		let lastError: PaymentError | null = null;
+
+		for (const method of this.methods) {
+			try {
+				const inner = await method.verify(payment, requirements);
+				const verification: MppVerification = {
+					payer: inner.payer,
+					methodType: method.type,
+					requirementIndex: getInnerRequirementIndex(inner),
+					inner,
+				};
+				return verification;
+			} catch (err) {
+				lastError =
+					err instanceof PaymentError
+						? err
+						: new PaymentError(
+								err instanceof Error ? err.message : "Verification failed",
+								402,
+							);
+			}
+		}
+
+		throw (
+			lastError ??
+			new PaymentError("Payment verification failed for all methods", 402)
+		);
+	}
+
+	async settle(verification: SettlementVerification): Promise<SettlementInfo> {
+		if (!isMppVerification(verification)) {
+			throw new PaymentError(
+				"settle() received a verification not produced by MppSettlement",
+				500,
+			);
+		}
+
+		const method = this.methods.find((m) => m.type === verification.methodType);
+		if (!method) {
+			throw new PaymentError(
+				`No method found for type: ${verification.methodType}`,
+				500,
+			);
+		}
+
+		const settlement = await method.settle(verification.inner);
+
+		log.info("mpp_settled", {
+			method: verification.methodType,
+			payer: settlement.payer,
+			tx: settlement.transaction,
+		});
+
+		return settlement;
+	}
+
+	/**
+	 * Reconstruct a verification from cached data.
+	 */
+	rebuildVerification(
+		_payment: unknown,
+		payer: string | undefined,
+		requirementIndex: number,
+		_requirements: PaymentRequirementsPayload[],
+	): SettlementVerification {
+		// Use the first (default) method for cache rebuilds — this assumes
+		// tempo is the primary method. If the cached index points to a
+		// different method, the verify loop will handle it on next miss.
+		const method = this.methods[0];
+		const verification: MppVerification = {
+			payer,
+			methodType: method.type,
+			requirementIndex,
+			inner: { payer },
+		};
+		return verification;
+	}
+
+	static getRequirementIndex(
+		verification: SettlementVerification,
+	): number | undefined {
+		return isMppVerification(verification)
+			? verification.requirementIndex
+			: undefined;
+	}
+
+	// ── Internal ────────────────────────────────────────────────────────────
+
+	private sweepExpired(): void {
+		const now = Date.now();
+		for (const [key, entry] of this.challengeMap) {
+			if (entry.expiresAt <= now) {
+				this.challengeMap.delete(key);
+			}
+		}
+	}
+}
+
+function isMppVerification(v: SettlementVerification): v is MppVerification {
+	return "methodType" in v && "inner" in v;
+}
+
+function getInnerRequirementIndex(inner: SettlementVerification): number {
+	if ("requirementIndex" in inner) {
+		return (inner as { requirementIndex: number }).requirementIndex;
+	}
+	return 0;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,10 +311,11 @@ export interface SettlementStrategy {
 }
 
 export interface SettlementStrategyConfig {
-	strategy: "facilitator" | "custom" | "nanopayments";
+	strategy: "facilitator" | "custom" | "nanopayments" | "mpp";
 	url?: string;
 	module?: string;
 	network?: "testnet" | "mainnet";
+	methods?: Array<{ type: "tempo" } | { type: "stripe"; secretKey: string }>;
 }
 
 // ── Rate Limiting ────────────────────────────────────────────────────────────

--- a/src/x402/headers.ts
+++ b/src/x402/headers.ts
@@ -40,15 +40,34 @@ export function encodePaymentResponse(response: unknown): string {
 }
 
 /**
- * Extract the payer wallet address from a base64-encoded payment-signature header.
- * Checks common x402 payload shapes: payload.authorization.from, from, payer.
+ * Extract the payer wallet address from a payment header string.
+ *
+ * Handles both formats:
+ * - x402: base64-encoded JSON (from `payment-signature` header)
+ * - MPP: `Payment id="...", payload="..."` (from `Authorization` header)
+ *
+ * Checks common payload shapes: payload.authorization.from, from, payer.
  * Returns undefined if the header cannot be parsed or doesn't contain a payer.
  */
 export function extractPayerFromHeader(
 	paymentHeader: string,
 ): string | undefined {
 	try {
-		const payload = JSON.parse(atob(paymentHeader)) as Record<string, unknown>;
+		let payload: Record<string, unknown>;
+
+		if (paymentHeader.startsWith("Payment ")) {
+			// MPP format: parse the payload parameter
+			const payloadMatch = paymentHeader.match(/payload="([^"]+)"/);
+			if (!payloadMatch) return undefined;
+			// base64url decode
+			let base64 = payloadMatch[1].replace(/-/g, "+").replace(/_/g, "/");
+			while (base64.length % 4) base64 += "=";
+			payload = JSON.parse(atob(base64)) as Record<string, unknown>;
+		} else {
+			// x402 format: base64-encoded JSON
+			payload = JSON.parse(atob(paymentHeader)) as Record<string, unknown>;
+		}
+
 		return (
 			getNestedString(payload, "payload", "authorization", "from") ??
 			getNestedString(payload, "from") ??

--- a/src/x402/middleware.ts
+++ b/src/x402/middleware.ts
@@ -1,3 +1,5 @@
+import { serializeChallenge } from "../mpp/headers.js";
+import type { MppChallenge } from "../mpp/types.js";
 import type { ResolvedPrice } from "../pricing/resolver.js";
 import type { AcceptedPayment, PaymentRequirementsPayload } from "../types.js";
 import { encodePaymentRequired, HEADERS } from "./headers.js";
@@ -60,22 +62,32 @@ export function buildPaymentRequirements(
 
 /**
  * Create a 402 Payment Required response.
+ *
+ * When `mppChallenges` is provided, MPP `WWW-Authenticate: Payment` headers
+ * are added alongside the x402 `payment-required` header for dual-protocol
+ * compatibility.
  */
 export function createPaymentRequiredResponse(
 	requirements: PaymentRequirementsPayload[],
+	mppChallenges?: MppChallenge[],
 ): Response {
 	const body = JSON.stringify({
 		accepts: requirements.map((r) => ({ paymentRequirements: r })),
 	});
 	const encoded = encodePaymentRequired(requirements);
 
-	return new Response(body, {
-		status: 402,
-		headers: {
-			"Content-Type": "application/json",
-			[HEADERS.PAYMENT_REQUIRED]: encoded,
-		},
+	const headers = new Headers({
+		"Content-Type": "application/json",
+		[HEADERS.PAYMENT_REQUIRED]: encoded,
 	});
+
+	if (mppChallenges) {
+		for (const challenge of mppChallenges) {
+			headers.append("WWW-Authenticate", serializeChallenge(challenge));
+		}
+	}
+
+	return new Response(body, { status: 402, headers });
 }
 
 export class PaymentError extends Error {

--- a/src/x402/payer.ts
+++ b/src/x402/payer.ts
@@ -1,11 +1,28 @@
+import { isMppAuthorization, parseCredential } from "../mpp/headers.js";
 import { decodePaymentSignature, HEADERS } from "./headers.js";
 
 /**
- * Decode the payer address from the x402 payment-signature header.
+ * Decode the payer address from the payment header.
+ *
+ * Checks MPP `Authorization: Payment` first, then falls back to
+ * x402 `payment-signature`.
  */
 export function extractPayerFromPaymentHeader(
 	request: Request,
 ): string | undefined {
+	// MPP: Authorization: Payment id="...", payload="..."
+	const authHeader = request.headers.get("authorization");
+	if (authHeader && isMppAuthorization(authHeader)) {
+		const cred = parseCredential(authHeader);
+		if (cred?.payload) {
+			const payer = extractPayerFromPayload(
+				cred.payload as Record<string, unknown>,
+			);
+			if (payer) return payer;
+		}
+	}
+
+	// x402: payment-signature
 	const paymentHeader = request.headers.get(HEADERS.PAYMENT_SIGNATURE);
 	if (!paymentHeader) {
 		return undefined;
@@ -16,15 +33,23 @@ export function extractPayerFromPaymentHeader(
 			string,
 			unknown
 		>;
-		const payer =
-			getNestedString(payload, "payload", "authorization", "from") ??
-			getNestedString(payload, "from") ??
-			getNestedString(payload, "payer");
-
-		return payer ? payer.toLowerCase() : undefined;
+		return extractPayerFromPayload(payload);
 	} catch {
 		return undefined;
 	}
+}
+
+/**
+ * Extract payer address from a decoded payment payload.
+ */
+function extractPayerFromPayload(
+	payload: Record<string, unknown>,
+): string | undefined {
+	const payer =
+		getNestedString(payload, "payload", "authorization", "from") ??
+		getNestedString(payload, "from") ??
+		getNestedString(payload, "payer");
+	return payer ? payer.toLowerCase() : undefined;
 }
 
 function getNestedString(


### PR DESCRIPTION
## Summary
- Adds `settlement.strategy: "mpp"` with pluggable payment methods (tempo for stablecoins, stripe for fiat cards)
- Dual-header support: 402 responses include both x402 (`payment-required`) and MPP (`WWW-Authenticate: Payment`) headers
- Accepts payments via either `payment-signature` (x402) or `Authorization: Payment` (MPP)
- Receipts include both `payment-response` (x402) and `Payment-Receipt` (MPP)
- 17 new tests, all 370 pass

### Config example
```yaml
settlement:
  strategy: mpp
  methods:
    - type: tempo        # stablecoins (wraps existing facilitator)
    - type: stripe       # fiat cards via Stripe SPT
      secretKey: "${STRIPE_SECRET_KEY}"
```

Closes #68

## Test plan
- [x] `npx tsc --noEmit` — type-check passes
- [x] `npx biome check src/` — lint clean
- [x] `npx vitest run` — 370/370 tests pass
- [x] Manual: `curl -v` a paid endpoint → verify `WWW-Authenticate: Payment` header on 402
- [x] Manual: send `Authorization: Payment` credential → verify 200 + `Payment-Receipt` header
- [x] Manual: send `payment-signature` (x402) with mpp strategy → backward compat works