### PR TITLE
[codex] add pkg.pr.new PR previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,24 @@ jobs:
       - run: npm run build
       - name: E2E smoke test (${{ matrix.runtime }} ${{ matrix.node-version }})
         run: bash scripts/e2e-runtime.sh ${{ matrix.runtime }}
+
+  pkg-pr-new:
+    if: github.event_name == 'pull_request'
+    needs:
+      - lint
+      - typecheck
+      - build
+      - test-node
+      - test-bun
+      - e2e-runtime
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Publish PR preview package
+        run: npx pkg-pr-new publish --bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
       - test-bun
       - e2e-runtime
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.publish.outputs.sha }}
+      urls: ${{ steps.publish.outputs.urls }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -114,5 +117,29 @@ jobs:
       - run: npm ci
       - name: Build
         run: npm run build
-      - name: Publish PR preview package
+      - id: publish
+        name: Publish PR preview package
         run: npx pkg-pr-new publish --bin
+
+  preview-e2e:
+    if: github.event_name == 'pull_request'
+    needs: pkg-pr-new
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install preview package into throwaway consumer dir
+        run: |
+          mkdir -p /tmp/tollbooth-preview
+          cd /tmp/tollbooth-preview
+          npm init -y
+          npm install ${{ needs.pkg-pr-new.outputs.urls }}
+      - name: Preview CLI smoke (installed tollbooth bin)
+        run: bash scripts/e2e-runtime.sh node /tmp/tollbooth-preview/node_modules/.bin/tollbooth
+      - name: Preview library smoke (imports from consumer dir)
+        run: |
+          cp scripts/e2e-preview-library.mjs /tmp/tollbooth-preview/
+          cd /tmp/tollbooth-preview
+          node e2e-preview-library.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x402-tollbooth",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x402-tollbooth",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.4.0",

--- a/scripts/e2e-preview-library.mjs
+++ b/scripts/e2e-preview-library.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Library-import smoke test for the pkg.pr.new preview.
+//
+// Run from a consumer dir that has `x402-tollbooth` installed (e.g. the
+// preview tarball from pkg-pr-new). Validates that the published package's
+// named exports resolve and that createGateway() can boot a gateway in-process.
+//
+// Exits 0 on success, non-zero on failure.
+
+import http from "node:http";
+import { createGateway } from "x402-tollbooth";
+
+const FAILURES = [];
+function expect(desc, ok, detail = "") {
+	if (ok) {
+		console.log(`  PASS: ${desc}`);
+	} else {
+		console.log(`  FAIL: ${desc}${detail ? ` — ${detail}` : ""}`);
+		FAILURES.push(desc);
+	}
+}
+
+// ── 1. Mock upstream on a random port ───────────────────────────────────────
+
+const upstream = http.createServer((req, res) => {
+	res.writeHead(200, { "content-type": "application/json" });
+	res.end(JSON.stringify({ method: req.method, path: req.url }));
+});
+await new Promise((resolve) => upstream.listen(0, resolve));
+const upstreamPort = upstream.address().port;
+console.log(`==> Mock upstream on port ${upstreamPort}`);
+
+// ── 2. Build a minimal config and boot the gateway ──────────────────────────
+
+const gwPort = 50000 + Math.floor(Math.random() * 10000);
+
+const config = {
+	gateway: { port: gwPort },
+	wallets: { "base-sepolia": "0xTestWallet" },
+	accepts: [{ asset: "USDC", network: "base-sepolia" }],
+	defaults: { price: "$0.01", timeout: 60 },
+	facilitator: "http://localhost:19999",
+	upstreams: { api: { url: `http://localhost:${upstreamPort}` } },
+	routes: { "GET /free": { upstream: "api", price: "$0" } },
+};
+
+const gateway = createGateway(config);
+await gateway.start({ silent: true });
+console.log(`==> Gateway on port ${gwPort}`);
+
+const base = `http://localhost:${gwPort}`;
+
+// ── 3. Smoke tests ──────────────────────────────────────────────────────────
+
+console.log("");
+console.log("=== Library smoke tests ===");
+
+try {
+	{
+		const res = await fetch(`${base}/health`);
+		const body = await res.text();
+		expect(
+			"GET /health returns 200",
+			res.status === 200 && body.includes('"status":"ok"'),
+			`status=${res.status} body=${body}`,
+		);
+	}
+	{
+		const res = await fetch(`${base}/free`);
+		const body = await res.text();
+		expect(
+			"GET /free proxies to upstream",
+			res.status === 200 && body.includes('"path":"/free"'),
+			`status=${res.status} body=${body}`,
+		);
+	}
+	{
+		const res = await fetch(`${base}/nonexistent`);
+		expect(
+			"GET /nonexistent returns 404",
+			res.status === 404,
+			`status=${res.status}`,
+		);
+	}
+} finally {
+	await gateway.stop();
+	upstream.close();
+}
+
+console.log("");
+if (FAILURES.length > 0) {
+	console.log(`FAILED (${FAILURES.length})`);
+	process.exit(1);
+}
+console.log("OK");

--- a/scripts/e2e-runtime.sh
+++ b/scripts/e2e-runtime.sh
@@ -2,13 +2,19 @@
 set -euo pipefail
 
 # ── E2E runtime smoke test ──────────────────────────────────────────────────
-# Usage: bash scripts/e2e-runtime.sh <node|bun>
+# Usage: bash scripts/e2e-runtime.sh <node|bun> [cli-command]
 #
-# Boots the built gateway CLI under the given runtime, starts a mock upstream,
-# and verifies basic HTTP behaviour (health, free proxy, 404).
+# Boots the gateway CLI, starts a mock upstream, verifies basic HTTP behaviour
+# (health, free proxy, 404).
+#
+# With one arg, runs the local build: "<runtime> dist/cli.js start ...".
+# With a second arg, runs that command directly (e.g. an installed bin like
+# /tmp/preview/node_modules/.bin/tollbooth). The runtime arg is kept for
+# labelling in that case.
 # ────────────────────────────────────────────────────────────────────────────
 
-RUNTIME="${1:?Usage: $0 <node|bun>}"
+RUNTIME="${1:?Usage: $0 <node|bun> [cli-command]}"
+CLI_CMD="${2:-}"
 PASS=0
 FAIL=0
 PIDS=()
@@ -74,7 +80,12 @@ EOF
 
 # ── 3. Start gateway ───────────────────────────────────────────────────────
 
-"$RUNTIME" dist/cli.js start --config=/tmp/tollbooth-e2e.yml > /tmp/e2e-gw.log 2>&1 &
+if [ -n "$CLI_CMD" ]; then
+  # shellcheck disable=SC2086
+  $CLI_CMD start --config=/tmp/tollbooth-e2e.yml > /tmp/e2e-gw.log 2>&1 &
+else
+  "$RUNTIME" dist/cli.js start --config=/tmp/tollbooth-e2e.yml > /tmp/e2e-gw.log 2>&1 &
+fi
 PIDS+=($!)
 
 # Wait for gateway to be ready (up to 10s)


### PR DESCRIPTION
## Summary
- add a `pkg-pr-new` job to the CI workflow for pull requests
- wait for the existing lint, typecheck, build, test, and e2e jobs before publishing a preview
- build the package and publish a PR preview with `npx pkg-pr-new publish --bin`

## Why
This gives each PR a consumable preview package so changes can be tested before merge without publishing to npm.

## Notes
- `--bin` is enabled because `x402-tollbooth` is also a CLI package.
- The `pkg.pr.new` GitHub App needs to be installed on this repository for the preview publishes to succeed.

## Validation
- parsed `.github/workflows/ci.yml` with Ruby's YAML loader
- ran `git diff --check`
