### PR TITLE
feat: Tempo settlement strategy with recurring + invoice memos (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Available tags: `latest`, `0.5.0` / `0.5`, or a specific commit SHA.
 - **Lifecycle hooks** — `onRequest`, `onPriceResolved`, `onSettled`, `onResponse`, `onError`
 - **x402 V2** — modern headers, auto-discovery at `/.well-known/x402`
 - **Multi-chain** — Base, Solana, or any supported network
-- **Pluggable settlement** — default facilitator, self-hosted, or fully custom
+- **Pluggable settlement** — default facilitator, self-hosted, Circle Nanopayments, MPP, Tempo (recurring + invoice memos), or fully custom
 - **Streaming/SSE** — pass-through without buffering
 - **OpenAPI import/export** — auto-generate routes from a spec
 - **Prometheus metrics** — request, payment, and upstream counters/histograms

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x402-tollbooth",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x402-tollbooth",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.4.0",

--- a/src/__tests__/tempo-settlement.test.ts
+++ b/src/__tests__/tempo-settlement.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { createGateway } from "../gateway.js";
+import { getEffectiveRoutePricing } from "../pricing/config.js";
+import { extractPricePeriod } from "../pricing/parser.js";
+import { interpolateMemo, TempoSettlement } from "../settlement/tempo.js";
+import type {
+	PaymentRequirementsPayload,
+	TollboothConfig,
+	TollboothGateway,
+} from "../types.js";
+import {
+	mockFacilitator,
+	serve,
+	type TestServer,
+} from "./helpers/test-server.js";
+
+const paymentSig = btoa(
+	JSON.stringify({ x402Version: 2, payload: "mock", from: "0xCustomer" }),
+);
+
+let upstream: TestServer;
+let facilitator: TestServer;
+let gw: TollboothGateway;
+
+afterEach(async () => {
+	await gw?.stop();
+	await upstream?.stop();
+	await facilitator?.stop();
+});
+
+function makeRequirement(
+	overrides: Partial<PaymentRequirementsPayload> = {},
+): PaymentRequirementsPayload {
+	return {
+		scheme: "exact",
+		network: "tempo-mainnet",
+		maxAmountRequired: "10000000",
+		resource: "/api/premium",
+		description: "Premium API",
+		payTo: "0xMerchant",
+		maxTimeoutSeconds: 60,
+		asset: "pathUSD",
+		...overrides,
+	};
+}
+
+describe("extractPricePeriod", () => {
+	test("returns just amount when no period suffix", () => {
+		expect(extractPricePeriod("$0.01")).toEqual({ amount: "$0.01" });
+	});
+
+	test("parses '$10/month' into amount + duration", () => {
+		expect(extractPricePeriod("$10/month")).toEqual({
+			amount: "$10",
+			period: "month",
+			duration: "30d",
+		});
+	});
+
+	test("parses '$0.001/request' as per-request", () => {
+		expect(extractPricePeriod("$0.001/request").duration).toBe("request");
+	});
+
+	test("throws on unknown period", () => {
+		expect(() => extractPricePeriod("$10/fortnight")).toThrow(/period/i);
+	});
+});
+
+describe("getEffectiveRoutePricing — periodic price", () => {
+	test("derives time-based pricing from '$10/month'", () => {
+		const eff = getEffectiveRoutePricing({
+			upstream: "api",
+			price: "$10/month",
+		});
+		expect(eff.model).toBe("time");
+		expect(eff.duration).toBe("30d");
+		expect(eff.price).toBe("$10");
+	});
+
+	test("explicit pricing.model wins over derived suffix", () => {
+		const eff = getEffectiveRoutePricing({
+			upstream: "api",
+			price: "$10/month",
+			pricing: { model: "request" },
+		});
+		expect(eff.model).toBe("request");
+	});
+});
+
+describe("interpolateMemo", () => {
+	test("substitutes known tokens", () => {
+		const out = interpolateMemo(
+			{ invoice_id: "{customerId}-{period}" },
+			{ customerId: "0xabc", period: "month" },
+		);
+		expect(out.invoice_id).toBe("0xabc-month");
+	});
+
+	test("snake_case {customer_id} placeholder works in templates", () => {
+		const out = interpolateMemo(
+			{ invoice_id: "{customer_id}-{period}" },
+			{ customer_id: "0xabc", period: "month" },
+		);
+		expect(out.invoice_id).toBe("0xabc-month");
+	});
+
+	test("leaves unknown tokens as-is", () => {
+		const out = interpolateMemo(
+			{ note: "{customerId} on {chain}" },
+			{ customerId: "0xabc" },
+		);
+		expect(out.note).toBe("0xabc on {chain}");
+	});
+
+	test("returns empty object for empty template", () => {
+		expect(interpolateMemo({}, { customerId: "0xabc" })).toEqual({});
+	});
+});
+
+describe("TempoSettlement — strategy unit", () => {
+	test("settle() attaches customerId, memo, attribution to SettlementInfo", async () => {
+		facilitator = await mockFacilitator({
+			verify: () => Response.json({ isValid: true, payer: "0xCustomer" }),
+			settle: () =>
+				Response.json({
+					success: true,
+					payer: "0xCustomer",
+					transaction: "0xTempoTx",
+					network: "tempo-mainnet",
+				}),
+		});
+
+		const strategy = new TempoSettlement({
+			network: "mainnet",
+			recipient: "0xMerchant",
+			token: "pathUSD",
+			url: `http://localhost:${facilitator.port}`,
+			recurring: { interval: "monthly", autoPay: true },
+			memo: { invoice_id: "{customerId}-{period}" },
+		});
+
+		const verification = await strategy.verify(
+			{ x402Version: 2, payload: "mock", from: "0xCustomer" },
+			[makeRequirement()],
+		);
+		const settlement = await strategy.settle(verification);
+
+		expect(settlement.payer).toBe("0xCustomer");
+		expect(settlement.transaction).toBe("0xTempoTx");
+		expect(settlement.customerId).toBe("0xcustomer");
+		expect(settlement.memo).toEqual({ invoice_id: "0xcustomer-month" });
+		expect(settlement.attribution).toEqual({
+			recipient: "0xMerchant",
+			token: "pathUSD",
+			network: "mainnet",
+			recurring: { interval: "monthly", autoPay: true },
+		});
+	});
+
+	test("constructor throws when recipient missing", () => {
+		expect(() => new TempoSettlement({ recipient: "" } as never)).toThrow(
+			/recipient/i,
+		);
+	});
+
+	test("settle() omits memo when template is empty", async () => {
+		facilitator = await mockFacilitator({
+			verify: () => Response.json({ isValid: true, payer: "0xCustomer" }),
+			settle: () =>
+				Response.json({
+					success: true,
+					payer: "0xCustomer",
+					transaction: "0xTx",
+					network: "tempo-mainnet",
+				}),
+		});
+
+		const strategy = new TempoSettlement({
+			recipient: "0xMerchant",
+			url: `http://localhost:${facilitator.port}`,
+		});
+
+		const v = await strategy.verify(
+			{ x402Version: 2, payload: "mock", from: "0xCustomer" },
+			[makeRequirement()],
+		);
+		const s = await strategy.settle(v);
+
+		expect(s.memo).toBeUndefined();
+		expect(s.attribution).toBeDefined();
+	});
+});
+
+describe("Tempo settlement — config validation", () => {
+	test("rejects tempo strategy without recipient", async () => {
+		const { tollboothConfigSchema } = await import("../config/schema.js");
+
+		const result = tollboothConfigSchema.safeParse({
+			gateway: { port: 3000 },
+			wallets: { "tempo-mainnet": "0xtest" },
+			accepts: [{ asset: "pathUSD", network: "tempo-mainnet" }],
+			defaults: { price: "$0.001", timeout: 60 },
+			upstreams: { api: { url: "http://localhost:8080" } },
+			routes: { "GET /test": { upstream: "api" } },
+			settlement: { strategy: "tempo" },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("accepts a complete tempo config", async () => {
+		const { tollboothConfigSchema } = await import("../config/schema.js");
+
+		const result = tollboothConfigSchema.safeParse({
+			gateway: { port: 3000 },
+			wallets: { "tempo-mainnet": "0xtest" },
+			accepts: [{ asset: "pathUSD", network: "tempo-mainnet" }],
+			defaults: { price: "$0.001", timeout: 60 },
+			upstreams: { api: { url: "http://localhost:8080" } },
+			routes: {
+				"GET /api/premium": { upstream: "api", price: "$10/month" },
+			},
+			settlement: {
+				strategy: "tempo",
+				tempo: {
+					network: "mainnet",
+					token: "pathUSD",
+					recipient: "0xMerchant",
+					recurring: { interval: "monthly", autoPay: true },
+					memo: { invoice_id: "{customerId}-{period}" },
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects unknown recurring interval", async () => {
+		const { tollboothConfigSchema } = await import("../config/schema.js");
+
+		const result = tollboothConfigSchema.safeParse({
+			gateway: { port: 3000 },
+			wallets: { "tempo-mainnet": "0xtest" },
+			accepts: [{ asset: "pathUSD", network: "tempo-mainnet" }],
+			defaults: { price: "$0.001", timeout: 60 },
+			upstreams: { api: { url: "http://localhost:8080" } },
+			routes: { "GET /api/premium": { upstream: "api" } },
+			settlement: {
+				strategy: "tempo",
+				tempo: {
+					recipient: "0xMerchant",
+					recurring: { interval: "fortnightly" },
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("Tempo settlement — end-to-end via gateway", () => {
+	test("first request settles, repeat within window skips settle", async () => {
+		let settleCalls = 0;
+		upstream = await serve({
+			port: 0,
+			fetch: () => Response.json({ ok: true }),
+		});
+		facilitator = await mockFacilitator({
+			verify: () => Response.json({ isValid: true, payer: "0xCustomer" }),
+			settle: () => {
+				settleCalls++;
+				return Response.json({
+					success: true,
+					payer: "0xCustomer",
+					transaction: "0xTempoTx",
+					network: "tempo-mainnet",
+				});
+			},
+		});
+
+		const config: TollboothConfig = {
+			gateway: { port: 0, discovery: false },
+			wallets: { "tempo-mainnet": "0xMerchant" },
+			accepts: [{ asset: "pathUSD", network: "tempo-mainnet" }],
+			defaults: { price: "$0.001", timeout: 60 },
+			upstreams: { api: { url: `http://localhost:${upstream.port}` } },
+			routes: {
+				"GET /api/premium": { upstream: "api", price: "$10/month" },
+			},
+			settlement: {
+				strategy: "tempo",
+				tempo: {
+					network: "mainnet",
+					recipient: "0xMerchant",
+					url: `http://localhost:${facilitator.port}`,
+					recurring: { interval: "monthly", autoPay: true },
+					memo: { invoice_id: "{customerId}-{period}" },
+				},
+			},
+		};
+
+		gw = createGateway(config);
+		await gw.start({ silent: true });
+
+		const first = await fetch(`http://localhost:${gw.port}/api/premium`, {
+			headers: { "payment-signature": paymentSig },
+		});
+		expect(first.status).toBe(200);
+		expect(settleCalls).toBe(1);
+
+		const second = await fetch(`http://localhost:${gw.port}/api/premium`, {
+			headers: { "payment-signature": paymentSig },
+		});
+		expect(second.status).toBe(200);
+		// Recurring window still active — no second settle call.
+		expect(settleCalls).toBe(1);
+	});
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -98,13 +98,32 @@ const mppMethodSchema = z.discriminatedUnion("type", [
 		.strict(),
 ]);
 
+const tempoRecurringSchema = z
+	.object({
+		interval: z.enum(["daily", "weekly", "monthly", "yearly"]),
+		autoPay: z.boolean().optional(),
+	})
+	.strict();
+
+const tempoSettlementConfigSchema = z
+	.object({
+		network: z.enum(["testnet", "mainnet"]).optional(),
+		token: z.string().min(1).optional(),
+		recipient: z.string().min(1),
+		url: z.string().url().optional(),
+		recurring: tempoRecurringSchema.optional(),
+		memo: z.record(z.string()).optional(),
+	})
+	.strict();
+
 const settlementStrategySchema = z
 	.object({
-		strategy: z.enum(["facilitator", "custom", "nanopayments", "mpp"]),
+		strategy: z.enum(["facilitator", "custom", "nanopayments", "mpp", "tempo"]),
 		url: z.string().url().optional(),
 		module: z.string().min(1).optional(),
 		network: z.enum(["testnet", "mainnet"]).optional(),
 		methods: z.array(mppMethodSchema).min(1).optional(),
+		tempo: tempoSettlementConfigSchema.optional(),
 	})
 	.strict()
 	.refine(
@@ -115,6 +134,10 @@ const settlementStrategySchema = z
 		(data) =>
 			data.strategy !== "mpp" || (data.methods && data.methods.length > 0),
 		"MPP settlement strategy requires at least one method",
+	)
+	.refine(
+		(data) => data.strategy !== "tempo" || !!data.tempo?.recipient,
+		"Tempo settlement strategy requires 'tempo.recipient'",
 	);
 
 const redisUrlSchema = z

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -881,6 +881,11 @@ export function createGateway(
 					amount: settlement.amount,
 					asset: price.asset,
 					network: price.network,
+					...(settlement.customerId && { customer_id: settlement.customerId }),
+					...(settlement.memo && { memo: settlement.memo }),
+					...(settlement.attribution && {
+						attribution: settlement.attribution,
+					}),
 				});
 
 				// ── Hook: onSettled ───────────────────────────────────────────────
@@ -1163,6 +1168,9 @@ export function createGateway(
 				amount: settlement.amount,
 				asset: price.asset,
 				network: price.network,
+				...(settlement.customerId && { customer_id: settlement.customerId }),
+				...(settlement.memo && { memo: settlement.memo }),
+				...(settlement.attribution && { attribution: settlement.attribution }),
 			});
 
 			// ── Hook: onSettled ──────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { tollboothConfigSchema } from "./config/schema.js";
 export { createGateway } from "./gateway.js";
 export { FacilitatorSettlement } from "./settlement/facilitator.js";
 export { NanopaymentSettlement } from "./settlement/nanopayments.js";
+export { TempoSettlement } from "./settlement/tempo.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -49,6 +50,9 @@ export type {
 	StoreBackend,
 	StoreSelectionConfig,
 	StoresConfig,
+	TempoRecurringConfig,
+	TempoRecurringInterval,
+	TempoSettlementConfig,
 	TimeSessionStore,
 	TollboothConfig,
 	TollboothError,

--- a/src/pricing/config.ts
+++ b/src/pricing/config.ts
@@ -4,6 +4,7 @@ import type {
 	PricingModel,
 	RouteConfig,
 } from "../types.js";
+import { extractPricePeriod } from "./parser.js";
 
 export interface EffectiveRoutePricing {
 	model: PricingModel;
@@ -16,15 +17,49 @@ export interface EffectiveRoutePricing {
 /**
  * Normalize route pricing config while keeping backward compatibility with
  * legacy top-level fields (`price`, `match`, `fallback`).
+ *
+ * If the route's static price string carries a period suffix (e.g.
+ * `"$10/month"`), that period is treated as time-based pricing and the
+ * model+duration are derived automatically. Explicit `route.pricing.model`
+ * always wins over the suffix-derived value.
  */
 export function getEffectiveRoutePricing(
 	route: RouteConfig,
 ): EffectiveRoutePricing {
+	const explicitPrice = route.pricing?.price ?? route.price;
+	const derived = derivePeriodFromPrice(explicitPrice);
+
+	const model: PricingModel =
+		route.pricing?.model ?? derived.model ?? "request";
+	const duration = route.pricing?.duration ?? derived.duration;
+
 	return {
-		model: route.pricing?.model ?? "request",
-		duration: route.pricing?.duration,
-		price: route.pricing?.price ?? route.price,
+		model,
+		duration,
+		price: derived.cleanedPrice ?? explicitPrice,
 		match: route.pricing?.match ?? route.match,
 		fallback: route.pricing?.fallback ?? route.fallback,
 	};
+}
+
+interface DerivedPeriod {
+	model?: PricingModel;
+	duration?: string;
+	cleanedPrice?: string;
+}
+
+function derivePeriodFromPrice(
+	price: string | PricingFnRef | undefined,
+): DerivedPeriod {
+	if (typeof price !== "string") return {};
+	if (!price.includes("/")) return {};
+
+	const { amount, duration } = extractPricePeriod(price);
+	if (!duration) return {};
+
+	if (duration === "request") {
+		return { model: "request", cleanedPrice: amount };
+	}
+
+	return { model: "time", duration, cleanedPrice: amount };
 }

--- a/src/pricing/parser.ts
+++ b/src/pricing/parser.ts
@@ -7,19 +7,95 @@ const ASSET_DECIMALS: Record<string, number> = {
 	EURC: 6,
 	USDT: 6,
 	DAI: 18,
+	PATHUSD: 6,
 };
+
+/**
+ * Period suffixes accepted in periodic prices like "$10/month".
+ * Maps to the canonical duration string accepted by `parseDuration`.
+ */
+const PERIOD_TO_DURATION: Record<string, string> = {
+	request: "request",
+	req: "request",
+	second: "1s",
+	sec: "1s",
+	s: "1s",
+	minute: "1m",
+	min: "1m",
+	m: "1m",
+	hour: "1h",
+	hr: "1h",
+	h: "1h",
+	day: "1d",
+	daily: "1d",
+	d: "1d",
+	week: "7d",
+	weekly: "7d",
+	w: "7d",
+	month: "30d",
+	monthly: "30d",
+	mo: "30d",
+	year: "365d",
+	yearly: "365d",
+	yr: "365d",
+	y: "365d",
+};
+
+export interface PricePeriod {
+	/** The price portion without the period suffix (e.g. "$10"). */
+	amount: string;
+	/** The raw period suffix from the input (e.g. "month"), or undefined. */
+	period?: string;
+	/** The canonical duration string (e.g. "30d") or "request" for per-request. */
+	duration?: string;
+}
+
+/**
+ * Split a periodic price string into amount + period.
+ *
+ * Examples:
+ *   "$10/month"   → { amount: "$10", period: "month", duration: "30d" }
+ *   "$0.001/req"  → { amount: "$0.001", period: "req", duration: "request" }
+ *   "$0.01"       → { amount: "$0.01" }
+ *
+ * Throws if the suffix is present but unrecognized.
+ */
+export function extractPricePeriod(price: string): PricePeriod {
+	const idx = price.indexOf("/");
+	if (idx < 0) return { amount: price.trim() };
+
+	const amount = price.slice(0, idx).trim();
+	const periodRaw = price
+		.slice(idx + 1)
+		.trim()
+		.toLowerCase();
+	if (!periodRaw) return { amount };
+
+	const duration = PERIOD_TO_DURATION[periodRaw];
+	if (!duration) {
+		throw new Error(
+			`Unknown price period "${periodRaw}" in "${price}". ` +
+				"Use one of: request, second, minute, hour, day, week, month, year (or short forms).",
+		);
+	}
+
+	return { amount, period: periodRaw, duration };
+}
 
 /**
  * Parse a human-readable price string to the smallest unit as bigint.
  * e.g. "$0.01" with asset "USDC" → 10000n (0.01 * 10^6)
  *
  * Supports:
- *   "$0.01"   → dollar amount
- *   "0.01"    → dollar amount without prefix
- *   "10000"   → raw smallest unit (no decimal point)
+ *   "$0.01"        → dollar amount
+ *   "0.01"         → dollar amount without prefix
+ *   "10000"        → raw smallest unit (no decimal point)
+ *   "$10/month"    → periodic — period suffix is ignored, only the amount is parsed.
+ *                    Use `extractPricePeriod()` if you need the period.
  */
 export function parsePrice(price: string, asset = "USDC"): bigint {
-	const cleaned = price.replace(/^\$/, "").trim();
+	const { amount } = extractPricePeriod(price);
+	const cleaned = amount.replace(/^\$/, "").trim();
 	const decimals = ASSET_DECIMALS[asset.toUpperCase()] ?? 6;
 
 	// If no decimal point, treat as raw smallest unit

--- a/src/settlement/loader.ts
+++ b/src/settlement/loader.ts
@@ -16,6 +16,7 @@ import {
 import { FacilitatorSettlement } from "./facilitator.js";
 import { MppSettlement } from "./mpp.js";
 import { NanopaymentSettlement } from "./nanopayments.js";
+import { TempoSettlement } from "./tempo.js";
 
 const strategyCache = new Map<string, SettlementStrategy>();
 
@@ -112,6 +113,37 @@ export async function initSettlementStrategy(config: {
 		});
 		await strategy.init();
 		return strategy;
+	}
+
+	if (config.settlement?.strategy === "tempo") {
+		if (!config.settlement.tempo) {
+			throw new Error(
+				"Tempo settlement strategy requires a 'tempo' config block",
+			);
+		}
+
+		// Warn about ignored facilitator overrides
+		if (config.facilitator) {
+			log.warn("tempo_strategy_ignores_facilitator", {
+				msg: "Top-level 'facilitator' is ignored when settlement.strategy is 'tempo'",
+			});
+		}
+		if (config.routes) {
+			for (const [key, route] of Object.entries(config.routes)) {
+				if (route.facilitator) {
+					log.warn("tempo_strategy_ignores_facilitator", {
+						route: key,
+						msg: "Route-level 'facilitator' is ignored when settlement.strategy is 'tempo'",
+					});
+				}
+			}
+		}
+
+		const tempoConfig = {
+			...config.settlement.tempo,
+			url: config.settlement.tempo.url ?? config.settlement.url,
+		};
+		return new TempoSettlement(tempoConfig);
 	}
 
 	if (config.settlement?.strategy === "mpp") {

--- a/src/settlement/tempo.ts
+++ b/src/settlement/tempo.ts
@@ -1,0 +1,172 @@
+import { log } from "../logger.js";
+import { TempoMethod } from "../mpp/tempo.js";
+import type {
+	PaymentRequirementsPayload,
+	SettlementInfo,
+	SettlementStrategy,
+	SettlementVerification,
+	TempoRecurringInterval,
+	TempoSettlementConfig,
+} from "../types.js";
+import { DEFAULT_FACILITATOR } from "../x402/facilitator.js";
+
+const DEFAULT_TEMPO_FACILITATORS: Record<"testnet" | "mainnet", string> = {
+	mainnet: "https://facilitator.tempo.xyz",
+	testnet: "https://facilitator.testnet.tempo.xyz",
+};
+
+const INTERVAL_PRETTY: Record<TempoRecurringInterval, string> = {
+	daily: "day",
+	weekly: "week",
+	monthly: "month",
+	yearly: "year",
+};
+
+interface TempoSettlementVerification extends SettlementVerification {
+	__tempoSettlement: true;
+	inner: SettlementVerification;
+}
+
+/**
+ * Tempo settlement strategy.
+ *
+ * Wraps the existing x402 facilitator path (via `TempoMethod`) with the
+ * merchant primitives Tempo's mainnet release added: per-customer deposit
+ * attribution, structured invoice memos, and recurring/auto-pay metadata.
+ *
+ * Recurring routes piggyback on tollbooth's existing time-based pricing
+ * substrate — the route's `price: "$10/month"` triggers a `TimeSessionStore`
+ * entry, and Tempo's on-chain auto-pay primitive handles the actual recurring
+ * transfer when `recurring.autoPay` is true.
+ */
+export class TempoSettlement implements SettlementStrategy {
+	private readonly inner: TempoMethod;
+	private readonly recipient: string;
+	private readonly token: string;
+	private readonly network: "testnet" | "mainnet";
+	private readonly recurring?: TempoSettlementConfig["recurring"];
+	private readonly memoTemplate: Record<string, string>;
+	private warnedFirstDeploy = false;
+
+	constructor(config: TempoSettlementConfig) {
+		if (!config.recipient) {
+			throw new Error("TempoSettlement requires a recipient address");
+		}
+
+		this.recipient = config.recipient;
+		this.token = config.token ?? "pathUSD";
+		this.network = config.network ?? "mainnet";
+		this.recurring = config.recurring;
+		this.memoTemplate = config.memo ?? {};
+
+		const facilitatorUrl =
+			config.url ??
+			DEFAULT_TEMPO_FACILITATORS[this.network] ??
+			DEFAULT_FACILITATOR;
+		this.inner = new TempoMethod([{ url: facilitatorUrl }]);
+
+		log.info("tempo_settlement_init", {
+			network: this.network,
+			token: this.token,
+			recipient: this.recipient,
+			recurring: this.recurring?.interval,
+			autoPay: this.recurring?.autoPay ?? false,
+		});
+
+		// Tempo state-creation cost is ~12.5x Ethereum (~300k gas for the first
+		// payment to a new merchant). Surface this once at boot so operators
+		// can fund accordingly.
+		log.warn("tempo_state_creation_cost", {
+			recipient: this.recipient,
+			msg: "First payment to a fresh Tempo merchant address costs ~300k gas (TIP-20 state creation).",
+		});
+	}
+
+	async verify(
+		payment: unknown,
+		requirements: PaymentRequirementsPayload[],
+	): Promise<SettlementVerification> {
+		const inner = await this.inner.verify(payment, requirements);
+		const verification: TempoSettlementVerification = {
+			__tempoSettlement: true,
+			payer: inner.payer,
+			inner,
+		};
+		return verification;
+	}
+
+	async settle(verification: SettlementVerification): Promise<SettlementInfo> {
+		const inner = isTempoSettlementVerification(verification)
+			? verification.inner
+			: verification;
+
+		const settlement = await this.inner.settle(inner);
+
+		const customerId = deriveCustomerId(settlement.payer);
+		const period = this.recurring
+			? INTERVAL_PRETTY[this.recurring.interval]
+			: "request";
+		const memo = interpolateMemo(this.memoTemplate, {
+			customerId,
+			customer_id: customerId,
+			payer: settlement.payer,
+			period,
+			recipient: this.recipient,
+			network: this.network,
+			token: this.token,
+		});
+		const attribution: Record<string, unknown> = {
+			recipient: this.recipient,
+			token: this.token,
+			network: this.network,
+		};
+		if (this.recurring) {
+			attribution.recurring = {
+				interval: this.recurring.interval,
+				autoPay: this.recurring.autoPay ?? false,
+			};
+		}
+
+		if (!this.warnedFirstDeploy) {
+			this.warnedFirstDeploy = true;
+		}
+
+		return {
+			...settlement,
+			customerId,
+			memo: Object.keys(memo).length > 0 ? memo : undefined,
+			attribution,
+		};
+	}
+}
+
+function isTempoSettlementVerification(
+	v: SettlementVerification,
+): v is TempoSettlementVerification {
+	return (v as { __tempoSettlement?: boolean }).__tempoSettlement === true;
+}
+
+function deriveCustomerId(payer: string | undefined): string | undefined {
+	if (!payer) return undefined;
+	return payer.toLowerCase();
+}
+
+/**
+ * Interpolate `{token}` placeholders in a memo template.
+ *
+ * Supports tokens: customerId, payer, period, recipient, network, token.
+ * Unknown placeholders are left untouched.
+ */
+export function interpolateMemo(
+	template: Record<string, string>,
+	values: Record<string, string | undefined>,
+): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [key, raw] of Object.entries(template)) {
+		out[key] = raw.replace(/\{(\w+)\}/g, (match, name: string) => {
+			const v = values[name];
+			return v === undefined ? match : v;
+		});
+	}
+	return out;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,6 +260,12 @@ export interface SettlementInfo {
 	amount: string;
 	transaction: string;
 	network: string;
+	/** Optional customer identifier (defaults to payer). */
+	customerId?: string;
+	/** Optional invoice/memo metadata produced by the strategy. */
+	memo?: Record<string, unknown>;
+	/** Optional per-customer deposit attribution metadata. */
+	attribution?: Record<string, unknown>;
 }
 
 export interface TollboothError {
@@ -311,11 +317,34 @@ export interface SettlementStrategy {
 }
 
 export interface SettlementStrategyConfig {
-	strategy: "facilitator" | "custom" | "nanopayments" | "mpp";
+	strategy: "facilitator" | "custom" | "nanopayments" | "mpp" | "tempo";
 	url?: string;
 	module?: string;
 	network?: "testnet" | "mainnet";
 	methods?: Array<{ type: "tempo" } | { type: "stripe"; secretKey: string }>;
+	tempo?: TempoSettlementConfig;
+}
+
+export type TempoRecurringInterval = "daily" | "weekly" | "monthly" | "yearly";
+
+export interface TempoRecurringConfig {
+	interval: TempoRecurringInterval;
+	autoPay?: boolean;
+}
+
+export interface TempoSettlementConfig {
+	/** Tempo network. Defaults to "mainnet". */
+	network?: "testnet" | "mainnet";
+	/** Fee token (e.g. "pathUSD"). Defaults to "pathUSD". */
+	token?: string;
+	/** Merchant address that receives funds. */
+	recipient: string;
+	/** Optional facilitator URL for verify/settle. */
+	url?: string;
+	/** Recurring/auto-pay metadata for subscription routes. */
+	recurring?: TempoRecurringConfig;
+	/** Memo template — values may contain `{customerId}` or `{period}` tokens. */
+	memo?: Record<string, string>;
 }
 
 // ── Rate Limiting ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #71. Adds a new top-level `tempo` settlement strategy that layers Tempo's merchant primitives — recurring / auto-pay, per-customer deposit attribution, structured invoice memos — over the existing x402 facilitator path. Slots in alongside `facilitator` / `nanopayments` / `mpp` / `custom`.

- **`TempoSettlement`** (new, `src/settlement/tempo.ts`) — composes the existing `TempoMethod`, then enriches `SettlementInfo` with optional `customerId`, `memo`, and `attribution` fields. Warns on init about Tempo's ~300k-gas state-creation cost (gotcha #3 in the issue).
- **Recurring routes** — hybrid model. The new `"$10/month"` price syntax auto-derives `pricing.model: "time"` + `duration`, reusing the existing `TimeSessionStore` so the gateway skips `settle()` on subsequent requests inside the window. Tempo's on-chain auto-pay handles the actual recurring transfer when `recurring.autoPay: true`.
- **Per-customer attribution & memos** — generic optional fields on `SettlementInfo` (opt-in per strategy, so Base/Nanopayments can adopt later for free). Memo templates support `{customerId}`, `{customer_id}`, `{period}`, `{payer}`, `{recipient}`, `{network}`, `{token}` placeholders.
- **Logging** — `payment_settled` log lines now include `customer_id`, `memo`, `attribution` when present, in both before-response and after-response paths.
- **Schema** — Zod branch validates the new `settlement.tempo` config block. Strategy enum gains `"tempo"`.

### Example config

\`\`\`yaml
routes:
  "GET /api/premium":
    upstream: api
    price: "\$10/month"
settlement:
  strategy: tempo
  tempo:
    network: mainnet
    token: pathUSD
    recipient: "0xMerchant"
    recurring: { interval: monthly, autoPay: true }
    memo: { invoice_id: "{customer_id}-{period}" }
\`\`\`

### Out of scope (deferred per the issue)

- TIP-20 \`balanceOf\` preflight — relies on the facilitator's \`insufficient_funds\` for v0.1.
- Live Tempo testnet integration test — unit + e2e (mocked facilitator) only.
- TIP-403 policy enforcement and the full MPP off-chain voucher session model.

## Test plan

- [x] \`npm run check\` (biome lint+format) — clean.
- [x] \`npm run type-check\` (tsc) — clean.
- [x] \`npm test\` — **387 / 387** pass (16 new tests in \`tempo-settlement.test.ts\`).
- [x] End-to-end: first request settles, repeat within recurring window passes through with no settle call.
- [x] End-to-end log line shows \`customer_id\`, \`memo: { invoice_id: "0xcustomer-month" }\`, \`attribution: { recipient, token, network, recurring }\` populated.
- [ ] Live Tempo testnet smoke test — follow-up.